### PR TITLE
USGS filter app update UI and add tab panels

### DIFF
--- a/R/USGS_filter_app/app.R
+++ b/R/USGS_filter_app/app.R
@@ -4,7 +4,7 @@ list.of.packages <- c("RColorBrewer","dataRetrieval", "skimr",
                       "ggplot2","leaflet","leafem","raster",
                       "raster","shiny","htmlwidgets","devtools",
                       "shinycssloaders","shinydashboard","shinyjs","DT","DBI",
-                      "spData","sf","shinythemes", "shinyalert", "plotly","tryCatchLog", "utf8", "stargazer")
+                      "spData","sf","shinythemes", "shinyalert", "plotly","tryCatchLog", "utf8")
 new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
 if(length(new.packages)) install.packages(new.packages)
 invisible(lapply(list.of.packages, require, character.only = TRUE))

--- a/R/USGS_filter_app/app.R
+++ b/R/USGS_filter_app/app.R
@@ -1,12 +1,12 @@
 ##############################################################################
-list.of.packages <- c("RColorBrewer","dataRetrieval",
+list.of.packages <- c("RColorBrewer","dataRetrieval", "skimr",
                       "curl","repr","maps","dplyr", "stringr",
                       "ggplot2","leaflet","leafem","raster",
                       "raster","shiny","htmlwidgets","devtools",
-                      "shinycustomloader","shinydashboard","shinyjs","DT","DBI",
-                      "spData","sf","shinythemes", "shinyalert", "plotly","tryCatchLog")
+                      "shinycssloaders","shinydashboard","shinyjs","DT","DBI",
+                      "spData","sf","shinythemes", "shinyalert", "plotly","tryCatchLog", "utf8", "stargazer")
 new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
 if(length(new.packages)) install.packages(new.packages)
-lapply(list.of.packages, require, character.only = TRUE)
+invisible(lapply(list.of.packages, require, character.only = TRUE))
 
 shinyApp(ui, server)

--- a/R/USGS_filter_app/server.R
+++ b/R/USGS_filter_app/server.R
@@ -1,3 +1,15 @@
+##############################################################################
+list.of.packages <- c("RColorBrewer","dataRetrieval",
+                      "curl","repr","maps","dplyr", "stringr",
+                      "ggplot2","leaflet","leafem","raster",
+                      "raster","shiny","htmlwidgets","devtools",
+                      "shinycustomloader","shinydashboard","shinyjs","DT","DBI",
+                      "spData","sf","shinythemes", "shinyalert", "plotly","tryCatchLog")
+new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
+if(length(new.packages)) install.packages(new.packages)
+lapply(list.of.packages, require, character.only = TRUE)
+##############################################################################
+
 server <- function(input, output, session) {
   
   ### Pop up disclaimer

--- a/R/USGS_filter_app/ui.R
+++ b/R/USGS_filter_app/ui.R
@@ -1,3 +1,15 @@
+##############################################################################
+list.of.packages <- c("RColorBrewer","dataRetrieval",
+                      "curl","repr","maps","dplyr", "stringr",
+                      "ggplot2","leaflet","leafem","raster",
+                      "raster","shiny","htmlwidgets","devtools",
+                      "shinycustomloader","shinydashboard","shinyjs","DT","DBI",
+                      "spData","sf","shinythemes", "shinyalert", "plotly","tryCatchLog")
+new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
+if(length(new.packages)) install.packages(new.packages)
+lapply(list.of.packages, require, character.only = TRUE)
+##############################################################################
+
 ui <- fluidPage(#theme="bootstrap.css",
   useShinyjs(),
   useShinyalert(), 

--- a/R/USGS_filter_app/ui.R
+++ b/R/USGS_filter_app/ui.R
@@ -16,11 +16,15 @@ ui <- fluidPage(#theme="bootstrap.css",
     ")),
   
   tags$style(".topimg {
-                            
                             margin-right:1%;
                             margin-top:0.8%;
                           }"),
   sidebarPanel(
+    sliderInput("Height",
+                "Map Height in Pixels:",
+                min = 200,
+                max = 800,
+                value = 500),
     tags$head(tags$script(src = "enter_button.js")),
     width = 3,
     textInput(inputId ="site_no", 
@@ -45,14 +49,19 @@ ui <- fluidPage(#theme="bootstrap.css",
               placeholder = "What is the Bounding Box delta?"),
     actionButton("getInfo", "Get site info"),
     downloadButton('data_file', 'Download Data'),
-    h4(''),
-    dataTableOutput('siteData')
+    h4('')
+    #dataTableOutput('siteData')
   ),
   
   mainPanel(
-    leafletOutput('map', width = "110%", height="500px"),
+    uiOutput("leaf"),
+    #leafletOutput('map'),
+    tabsetPanel(type = "tabs",
+                tabPanel("DataTable", dataTableOutput('siteData')),
+                tabPanel("Plot", withSpinner(plotlyOutput('bar'))),
+                tabPanel("Summary", verbatimTextOutput("summary"))),
     #br(),
-    plotlyOutput('bar', width = "110%"),
+    #plotlyOutput('bar', width = "110%"),
     tags$footer(align="center", 
                 style="font-size:100%", "Disclaimer: The information contained in this website is for demonstration purposes only. Any reliance you place on such information is therefore strictly at your own risk."
     )))


### PR DESCRIPTION
- Set Open Topo Map to default
- Add a sliderInput ui device to adjust the height of the map
- Add 3 tab panels beneath the map - redirect datatable output + bar chart + summary statistics (produced by skimr) to tab panel: Note, due to a known error, the skimr histograms failed to render: [problem description](https://r.789695.n4.nabble.com/Unicode-display-problem-with-data-frames-under-Windows-td4707639.html)
- Update bar chart, add geom_smooth() gam trend line (can easily remove if not well received)

To Do:
- Add Toggle buttons for sites in the Sidebar panel